### PR TITLE
chore: bump version to 0.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_helm"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ This is an example of providing configuration for the language server via Zed's 
 
 ## Credits
 https://github.com/ngalaiko/tree-sitter-go-template
+
+## Release Process
+
+Every time the extension is released:
+
+1. **Bump the Version:**  
+   Update the version number in Cargo.toml.
+
+2. **Update Extension Index:**  
+   After releasing, update the extension entry in [zed-industries/extensions](http://github.com/zed-industries/extensions/) to reflect the new version.
+
+This ensures users always have access to the latest
+


### PR DESCRIPTION
This is required to update the extension in https://github.com/zed-industries/extensions