### PR TITLE
Add .helmignore to path_suffixes and add Helm icon

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "helm"
 name = "Helm"
-version = "0.0.2"
+version = "0.0.3"
 schema_version = 1
 authors = [
     "cabrinha <yuppie@hey.com>",

--- a/languages/helm/config.toml
+++ b/languages/helm/config.toml
@@ -1,6 +1,7 @@
 name = "Helm"
 grammar = "helm"
 line_comments = ["# "]
+path_suffixes = [".helmignore"]
 block_comment = ["{{/* ", " */}}"]
 brackets = [
     { start = "{{", end = "}}", close = true, newline = false },


### PR DESCRIPTION
## Description

This is a PR to add `.helmignore` to `path_suffixes`. This allows the Helm icon to be displayed in the language selection menu.

---

Before -> After

<img width="1380" height="826" alt="2026-01-25 at 00 17 57@2x" src="https://github.com/user-attachments/assets/9f0295f4-e610-4c9e-8c39-9e98e0ef6a83" />
