### PR TITLE
fix: use latest available cargo edition version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zed_helm"
-version = "0.0.5"
-edition = "2026"
+version = "0.0.6"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "helm"
 name = "Helm"
-version = "0.0.5"
+version = "0.0.6"
 schema_version = 1
 authors = [
     "cabrinha <yuppie@hey.com>",


### PR DESCRIPTION
Fixes this issue: https://github.com/zed-industries/extensions/actions/runs/29669374379/job/88145545423#step:13:48

Can you update this upstream MR after you publish a new release?